### PR TITLE
Replace reactDOM.render with createRoot for React v18

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -5,6 +5,6 @@
   <title>Haiven</title>
 </head>
 <body>
-  <div id="root"></div>
+  <div id="app"></div>
 </body>
 </html>

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "react-dom";
+import { createRoot } from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { ChakraProvider } from "@chakra-ui/react";
 
@@ -13,8 +13,9 @@ import HomePage from "./pages/HomePage.tsx";
 import PartnersPage from "./pages/PartnersPage.tsx";
 import TeamPage from "./pages/TeamPage.tsx";
 
-const rootElement = document.getElementById("root");
-render(
+const app = document.getElementById("app");
+const root = createRoot(app);
+root.render(
   <ChakraProvider>
     <BrowserRouter>
       <Routes>
@@ -27,6 +28,5 @@ render(
         <Route path="team" element={<TeamPage />} />
       </Routes>
     </BrowserRouter>
-  </ChakraProvider>,
-  rootElement
+  </ChakraProvider>
 );


### PR DESCRIPTION
# Summary
This PR partially fixes issue #7 in which there's a console error regarding React v18 when loading the app.

# Details
- The console error still shows up because ChakraUI uses `reactDOM.render`. They are fixing it in [a future PR](https://github.com/chakra-ui/chakra-ui/issues/5855).
- To fully fix the console error, we can check the issue biweekly until they're done upgrading to ChakraUI v2.